### PR TITLE
Implement minimal fetcher integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ required build tools using `scripts/install_deps.sh` before running `mk`.
 
 ## Status
 
-At the moment this repository only contains a very small skeleton program
-and design notes. It does not yet provide any real browsing capability.
-
-A minimal skeleton program now fetches a URL and displays the contents in a
-window. See `doc/roadmap.md` for planned tasks.
+Gammera is still in an early stage, but a minimal program is able to
+retrieve a web page and show the raw text in a window. Pass a URL on the
+command line (or omit it to fetch `http://example.com/`).
+See `doc/roadmap.md` for planned tasks.

--- a/mkfile
+++ b/mkfile
@@ -1,13 +1,16 @@
 <$objtype/mkfile>
 
 TARG=gammera
-OFILES=src/main.$O
+OFILES=src/main.$O src/fetch.$O
 
 $TARG: $OFILES
 $LD -o $target $OFILES
 
-src/main.$O: src/main.c
+src/main.$O: src/main.c src/fetch.h
 $CC -c src/main.c
+
+src/fetch.$O: src/fetch.c src/fetch.h
+$CC -c src/fetch.c
 
 clean:V:
 rm -f src/*.[$OS] $TARG

--- a/src/main.c
+++ b/src/main.c
@@ -2,29 +2,41 @@
 #include <libc.h>
 #include <draw.h>
 #include <thread.h>
+#include "fetch.h"
 
 void
 usage(void)
 {
-    fprint(2, "usage: gammera\n");
+    fprint(2, "usage: gammera [url]\n");
     threadexitsall("usage");
 }
 
 void
 threadmain(int argc, char *argv[])
 {
+    char *url, *data;
+
     ARGBEGIN{ default: usage(); }ARGEND;
 
+    if(argc < 1)
+        url = "http://example.com/";
+    else
+        url = argv[0];
+
+    data = fetch_url(url);
+    if(data == nil)
+        sysfatal("fetch %s failed: %r", url);
 
     if(initdraw(nil, nil, "Gammera") < 0)
         sysfatal("initdraw failed: %r");
 
-    char *msg = "Gammera browser skeleton";
-    screen->r = insetrect(screen->r, 50);
-    draw(screen, screen->r, display->black, nil, ZP);
-    drawstring(screen, Pt(screen->r.min.x+10, screen->r.min.y+10), display->white, ZP, font, msg);
+    screen->r = insetrect(screen->r, 10);
+    draw(screen, screen->r, display->white, nil, ZP);
+    drawstring(screen, Pt(screen->r.min.x+10, screen->r.min.y+10), display->black, ZP, font, data);
     flushimage(display, 1);
+
+    free(data);
 
     for(;;)
         sleep(1000);
-
+}


### PR DESCRIPTION
## Summary
- extend the skeleton browser to fetch a URL and show it in the window
- compile `fetch.c` by default
- update the readme to describe new functionality

## Testing
- `mk all` *(fails: `mk` not found)*