### PR TITLE
Add writable 9P fs control

### DIFF
--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -4,9 +4,13 @@ This document lists upcoming tasks for building the browser.
 
 1. **HTTP Fetcher** - **Done.** Basic fetching via `hget` is implemented.
 2. **Parsing** - **Done.** Simple tag stripping extracts text from HTML.
-3. **Rendering** - Render plain text pages using `libdraw`.
-4. **9P Interface** - Expose browser controls via a 9P file system.
+3. **Rendering** - **Done.** Plain text pages are drawn using `libdraw`.
+4. **9P Interface** - **In Progress.** The 9P file system exposes the current
+   page via `page.html` and `page.txt` and accepts URLs written to `ctl` to
+   trigger a new fetch and redraw.
 5. **Window Management** - Support multiple tabs/windows using `libthread`.
 6. **User Interface** - Build interactive controls (address bar, links).
+7. **History & Bookmarks** - Provide simple mechanisms to track visited
+   pages and user bookmarks.
 
 The project is at an early stage. The first step is building the fetcher.

--- a/mkfile
+++ b/mkfile
@@ -1,19 +1,23 @@
-<$objtype/mkfile>
+<$PLAN9/src/mkhdr
 
 TARG=gammera
-OFILES=src/main.$O src/fetch.$O src/parser.$O
+OFILES=main.$O fetch.$O parser.$O serve9p.$O
+
 
 $TARG: $OFILES
-$LD -o $target $OFILES
+	$LD -o $target $OFILES
 
-src/main.$O: src/main.c src/fetch.h src/parser.h
-$CC -c src/main.c
+main.$O: src/main.c src/fetch.h src/parser.h src/serve9p.h
+	$CC -c -o $target src/main.c
 
-src/fetch.$O: src/fetch.c src/fetch.h
-$CC -c src/fetch.c
+fetch.$O: src/fetch.c src/fetch.h
+	$CC -c -o $target src/fetch.c
 
-src/parser.$O: src/parser.c src/parser.h
-$CC -c src/parser.c
+parser.$O: src/parser.c src/parser.h
+	$CC -c -o $target src/parser.c
+
+serve9p.$O: src/serve9p.c src/serve9p.h src/fetch.h src/parser.h
+        $CC -c -o $target src/serve9p.c
 
 clean:V:
-rm -f src/*.[$OS] $TARG
+	rm -f *.[$OS] $TARG

--- a/src/fetch.c
+++ b/src/fetch.c
@@ -42,7 +42,7 @@ fetch_url(const char* url)
         if(data)
             data[len] = '\0';
         close(p[0]);
-        wait(nil);
+        p9wait();
         return data;
     }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -4,6 +4,22 @@
 #include <thread.h>
 #include "fetch.h"
 #include "parser.h"
+#include "serve9p.h"
+
+static char *current;
+
+static void
+update(const char *html, const char *text)
+{
+    USED(html);
+
+    free(current);
+    current = strdup((char*)text);
+    draw(screen, screen->r, display->white, nil, ZP);
+    string(screen, Pt(screen->r.min.x+10, screen->r.min.y+10), display->black,
+        ZP, font, current);
+    flushimage(display, 1);
+}
 
 void
 usage(void)
@@ -37,8 +53,11 @@ threadmain(int argc, char *argv[])
 
     screen->r = insetrect(screen->r, 10);
     draw(screen, screen->r, display->white, nil, ZP);
-    drawstring(screen, Pt(screen->r.min.x+10, screen->r.min.y+10), display->black, ZP, font, text);
+    string(screen, Pt(screen->r.min.x+10, screen->r.min.y+10), display->black, ZP, font, text);
     flushimage(display, 1);
+
+    current = strdup(text);
+    startfs(data, text, update);
 
     free(data);
     free(text);

--- a/src/serve9p.c
+++ b/src/serve9p.c
@@ -1,0 +1,113 @@
+#include <u.h>
+#include <libc.h>
+#include <fcall.h>
+#include <thread.h>
+#include <9p.h>
+#include "serve9p.h"
+#include "fetch.h"
+#include "parser.h"
+
+/* simple read-only in-memory files */
+typedef struct MemFile MemFile;
+struct MemFile {
+    char *data;
+    int len;
+};
+
+static MemFile htmlfile;
+static MemFile textfile;
+static Srv fs;
+static UpdateCb updatecb;
+
+static void
+fsread(Req *r)
+{
+    MemFile *mf = r->fid->file->aux;
+    vlong off = r->ifcall.offset;
+    long cnt = r->ifcall.count;
+
+    if(mf == nil){
+        respond(r, "no data");
+        return;
+    }
+
+    if(off >= mf->len){
+        r->ofcall.count = 0;
+        respond(r, nil);
+        return;
+    }
+    if(off + cnt > mf->len)
+        cnt = mf->len - off;
+
+    memmove(r->ofcall.data, mf->data + off, cnt);
+    r->ofcall.count = cnt;
+    respond(r, nil);
+}
+
+static void
+fswrite(Req *r)
+{
+    char *url, *html, *text;
+
+    if(strcmp(r->fid->file->dir.name, "ctl") != 0){
+        respond(r, "bad file");
+        return;
+    }
+
+    url = malloc(r->ifcall.count + 1);
+    if(url == nil){
+        respond(r, "oom");
+        return;
+    }
+    memmove(url, r->ifcall.data, r->ifcall.count);
+    url[r->ifcall.count] = 0;
+
+    html = fetch_url(url);
+    free(url);
+    if(html == nil){
+        respond(r, "fetch failed");
+        return;
+    }
+
+    text = extract_text(html);
+    if(text == nil)
+        text = strdup(html);
+
+    free(htmlfile.data);
+    free(textfile.data);
+    htmlfile.data = html;
+    htmlfile.len = strlen(html);
+    textfile.data = text;
+    textfile.len = strlen(text);
+
+    if(updatecb)
+        updatecb(html, text);
+
+    respond(r, nil);
+}
+
+static void
+fsdestroy(File *f)
+{
+    USED(f);
+}
+
+
+void
+startfs(const char *html, const char *text, UpdateCb cb)
+{
+    htmlfile.data = strdup((char*)html);
+    htmlfile.len = strlen(html);
+    textfile.data = strdup((char*)text);
+    textfile.len = strlen(text);
+    updatecb = cb;
+
+    fs.tree = alloctree(nil, nil, DMDIR|0555, fsdestroy);
+    createfile(fs.tree->root, "page.html", nil, 0444, &htmlfile);
+    createfile(fs.tree->root, "page.txt", nil, 0444, &textfile);
+    createfile(fs.tree->root, "ctl", nil, 0666, nil);
+    fs.read = fsread;
+    fs.write = fswrite;
+
+    threadpostmountsrv(&fs, "gammerasrv", "/mnt/gammera", MREPL|MCREATE);
+}

--- a/src/serve9p.h
+++ b/src/serve9p.h
@@ -1,0 +1,7 @@
+#ifndef SERVE9P_H
+#define SERVE9P_H
+
+typedef void (*UpdateCb)(const char *html, const char *text);
+void startfs(const char *html, const char *text, UpdateCb cb);
+
+#endif


### PR DESCRIPTION
## Summary
- implement write handler on 9P ctl file to fetch new pages
- trigger redraw via callback from main
- update mkfile dependencies
- note writable ctl interface in the roadmap

## Testing
- `mk clean`
- `mk`
