### PR TITLE
Update build instructions and TLS deps

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Gammera
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ This will compile the sources under `src/` using the Plan 9 toolchain.
 For Linux or other Unix-like systems you can install plan9port and the
 required build tools using `scripts/install_deps.sh` before running `mk`.
 This script installs Plan9port and configures your PATH so the `mk` build tool is available.
+It also installs `libssl-dev` so that HTTPS support can be built. If you are
+on a native Plan 9 system, ensure the appropriate TLS library is installed
+(for example the 9front TLS tools).
+Note that the install script downloads packages from the network and may fail
+if your environment lacks internet access.
 
 ## Project Layout
 

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -10,7 +10,7 @@ P9SRC="$P9DIR/src"
 
 # Check and install required system packages
 echo "Checking system packages..."
-REQUIRED_PKGS="gcc make git x11-utils libx11-dev libxt-dev libxext-dev libfontconfig1-dev libfreetype6-dev"
+REQUIRED_PKGS="gcc make git x11-utils libx11-dev libxt-dev libxext-dev libfontconfig1-dev libfreetype6-dev libssl-dev"
 MISSING_PKGS=$(dpkg-query -W -f='${binary:Package}\n' $REQUIRED_PKGS 2>/dev/null | sort | uniq | comm -23 <(echo "$REQUIRED_PKGS" | tr ' ' '\n' | sort) -)
 
 if [ -n "$MISSING_PKGS" ]; then


### PR DESCRIPTION
## Summary
- install libssl-dev via `install_deps.sh`
- document TLS requirements and network usage in README
- add an MIT license file

## Testing
- `bash -n scripts/install_deps.sh`
- `gcc -c src/main.c src/fetch.c src/parser.c src/serve9p.c` *(fails: `u.h` not found)*