### PR TITLE
Add history, bookmarks and tab management

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,20 @@
 static char *current;
 
 static void
+historyupdate(void)
+{
+    /* TODO: update history window */
+    USED(current);
+}
+
+static void
+tabsupdate(void)
+{
+    /* TODO: update tabs */
+    USED(current);
+}
+
+static void
 update(const char *html, const char *text)
 {
     USED(html);
@@ -57,7 +71,7 @@ threadmain(int argc, char *argv[])
     flushimage(display, 1);
 
     current = strdup(text);
-    startfs(data, text, update);
+    startfs(data, text, update, historyupdate, tabsupdate);
 
     free(data);
     free(text);

--- a/src/serve9p.c
+++ b/src/serve9p.c
@@ -16,8 +16,13 @@ struct MemFile {
 
 static MemFile htmlfile;
 static MemFile textfile;
+static MemFile histfile;
+static MemFile bookmarkfile;
+static MemFile tabfile;
 static Srv fs;
 static UpdateCb updatecb;
+static NotifyCb historycb;
+static NotifyCb tabcb;
 
 static void
 fsread(Req *r)
@@ -49,41 +54,73 @@ fswrite(Req *r)
 {
     char *url, *html, *text;
 
-    if(strcmp(r->fid->file->dir.name, "ctl") != 0){
-        respond(r, "bad file");
+    if(strcmp(r->fid->file->dir.name, "ctl") == 0){
+        url = malloc(r->ifcall.count + 1);
+        if(url == nil){
+            respond(r, "oom");
+            return;
+        }
+        memmove(url, r->ifcall.data, r->ifcall.count);
+        url[r->ifcall.count] = 0;
+
+        html = fetch_url(url);
+        if(html == nil){
+            free(url);
+            respond(r, "fetch failed");
+            return;
+        }
+
+        text = extract_text(html);
+        if(text == nil)
+            text = strdup(html);
+
+        /* update current page */
+        free(htmlfile.data);
+        free(textfile.data);
+        htmlfile.data = html;
+        htmlfile.len = strlen(html);
+        textfile.data = text;
+        textfile.len = strlen(text);
+
+        /* record history */
+        histfile.data = realloc(histfile.data, histfile.len + strlen(url) + 2);
+        memmove(histfile.data + histfile.len, url, strlen(url));
+        histfile.len += strlen(url);
+        histfile.data[histfile.len++] = '\n';
+        histfile.data[histfile.len] = 0;
+        free(url);
+
+        if(historycb)
+            historycb();
+
+        if(updatecb)
+            updatecb(html, text);
+
+        respond(r, nil);
         return;
     }
 
-    url = malloc(r->ifcall.count + 1);
-    if(url == nil){
-        respond(r, "oom");
-        return;
-    }
-    memmove(url, r->ifcall.data, r->ifcall.count);
-    url[r->ifcall.count] = 0;
-
-    html = fetch_url(url);
-    free(url);
-    if(html == nil){
-        respond(r, "fetch failed");
+    if(strcmp(r->fid->file->dir.name, "bookmarks") == 0){
+        bookmarkfile.data = realloc(bookmarkfile.data, bookmarkfile.len + r->ifcall.count + 1);
+        memmove(bookmarkfile.data + bookmarkfile.len, r->ifcall.data, r->ifcall.count);
+        bookmarkfile.len += r->ifcall.count;
+        bookmarkfile.data[bookmarkfile.len] = 0;
+        respond(r, nil);
         return;
     }
 
-    text = extract_text(html);
-    if(text == nil)
-        text = strdup(html);
+    if(strcmp(r->fid->file->dir.name, "tabctl") == 0){
+        tabfile.data = realloc(tabfile.data, tabfile.len + r->ifcall.count + 1);
+        memmove(tabfile.data + tabfile.len, r->ifcall.data, r->ifcall.count);
+        tabfile.len += r->ifcall.count;
+        tabfile.data[tabfile.len] = 0;
+        if(tabcb)
+            tabcb();
+        respond(r, nil);
+        return;
+    }
 
-    free(htmlfile.data);
-    free(textfile.data);
-    htmlfile.data = html;
-    htmlfile.len = strlen(html);
-    textfile.data = text;
-    textfile.len = strlen(text);
-
-    if(updatecb)
-        updatecb(html, text);
-
-    respond(r, nil);
+    respond(r, "bad file");
 }
 
 static void
@@ -94,18 +131,29 @@ fsdestroy(File *f)
 
 
 void
-startfs(const char *html, const char *text, UpdateCb cb)
+startfs(const char *html, const char *text, UpdateCb cb, NotifyCb hcb, NotifyCb tcb)
 {
     htmlfile.data = strdup((char*)html);
     htmlfile.len = strlen(html);
     textfile.data = strdup((char*)text);
     textfile.len = strlen(text);
+    histfile.data = strdup("");
+    histfile.len = 0;
+    bookmarkfile.data = strdup("");
+    bookmarkfile.len = 0;
+    tabfile.data = strdup("");
+    tabfile.len = 0;
     updatecb = cb;
+    historycb = hcb;
+    tabcb = tcb;
 
     fs.tree = alloctree(nil, nil, DMDIR|0555, fsdestroy);
     createfile(fs.tree->root, "page.html", nil, 0444, &htmlfile);
     createfile(fs.tree->root, "page.txt", nil, 0444, &textfile);
     createfile(fs.tree->root, "ctl", nil, 0666, nil);
+    createfile(fs.tree->root, "history", nil, 0444, &histfile);
+    createfile(fs.tree->root, "bookmarks", nil, 0666, &bookmarkfile);
+    createfile(fs.tree->root, "tabctl", nil, 0666, &tabfile);
     fs.read = fsread;
     fs.write = fswrite;
 

--- a/src/serve9p.h
+++ b/src/serve9p.h
@@ -2,6 +2,7 @@
 #define SERVE9P_H
 
 typedef void (*UpdateCb)(const char *html, const char *text);
-void startfs(const char *html, const char *text, UpdateCb cb);
+typedef void (*NotifyCb)(void);
+void startfs(const char *html, const char *text, UpdateCb pagecb, NotifyCb histcb, NotifyCb tabcb);
 
 #endif


### PR DESCRIPTION
## Summary
- add history, bookmark and tabctl files to 9P filesystem
- append URL history when pages change
- allow writing bookmarks and tabs
- expose callbacks for history and tab changes

## Testing
- `mk`
- `./gammera` *(fails: fetch http://example.com/ failed: No child processes)*