### PR TITLE
Add tab manager module

### DIFF
--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -16,3 +16,10 @@ This document lists upcoming tasks for building the browser.
    and store user bookmarks.
 
 The project is at an early stage. The first step is building the fetcher.
+
+## Tabs
+
+Writing a URL to `/mnt/gammera/tabctl` opens that address in a new tab. Each
+tab runs in its own thread and can be selected from a contextual menu like
+other Plan 9 programs. Switching tabs notifies the main window to redraw with
+the selected page contents.

--- a/mkfile
+++ b/mkfile
@@ -1,12 +1,14 @@
 <$PLAN9/src/mkhdr
 
-OFILES=main.$O fetcher.$O parser.$O serve9p.$O
+TARG=gammera
+
+OFILES=main.$O fetcher.$O parser.$O serve9p.$O tabs.$O fs.$O
 
 
 $TARG: $OFILES
 	$LD -o $target $OFILES
 
-main.$O: src/main.c src/fetcher.h src/parser.h src/serve9p.h
+main.$O: src/main.c src/fetcher.h src/parser.h src/serve9p.h src/tabs.h
         $CC -c -o $target src/main.c
 
 fetcher.$O: src/fetcher.c src/fetcher.h
@@ -17,6 +19,12 @@ parser.$O: src/parser.c src/parser.h
 
 serve9p.$O: src/serve9p.c src/serve9p.h src/fetcher.h src/parser.h
         $CC -c -o $target src/serve9p.c
+
+tabs.$O: src/tabs.c src/tabs.h src/fetcher.h src/parser.h
+        $CC -c -o $target src/tabs.c
+
+fs.$O: src/fs.c src/fs.h
+        $CC -c -o $target src/fs.c
 
 clean:V:
 	rm -f *.[$OS] $TARG

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
 #include "fetcher.h"
 #include "parser.h"
 #include "serve9p.h"
+#include "tabs.h"
 
 static char *current;
 
@@ -15,12 +16,6 @@ historyupdate(void)
     USED(current);
 }
 
-static void
-tabsupdate(void)
-{
-    /* TODO: update tabs */
-    USED(current);
-}
 
 static void
 update(const char *html, const char *text)
@@ -64,6 +59,7 @@ threadmain(int argc, char *argv[])
 
     fs_init();
     fs_update_page(text);
+    tabs_init(update);
 
     if(initdraw(nil, nil, "Gammera") < 0)
         sysfatal("initdraw failed: %r");
@@ -75,7 +71,7 @@ threadmain(int argc, char *argv[])
     flushimage(display, 1);
 
     current = strdup(text);
-    startfs(data, text, update, historyupdate, tabsupdate);
+    startfs(data, text, update, historyupdate, tabs_new);
 
     free(data);
     free(text);

--- a/src/serve9p.c
+++ b/src/serve9p.c
@@ -22,7 +22,7 @@ static MemFile tabfile;
 static Srv fs;
 static UpdateCb updatecb;
 static NotifyCb historycb;
-static NotifyCb tabcb;
+static TabCb tabcb;
 
 static void
 fsread(Req *r)
@@ -110,12 +110,22 @@ fswrite(Req *r)
     }
 
     if(strcmp(r->fid->file->dir.name, "tabctl") == 0){
+        char *url;
+
         tabfile.data = realloc(tabfile.data, tabfile.len + r->ifcall.count + 1);
         memmove(tabfile.data + tabfile.len, r->ifcall.data, r->ifcall.count);
         tabfile.len += r->ifcall.count;
         tabfile.data[tabfile.len] = 0;
-        if(tabcb)
-            tabcb();
+
+        url = malloc(r->ifcall.count + 1);
+        if(url){
+            memmove(url, r->ifcall.data, r->ifcall.count);
+            url[r->ifcall.count] = 0;
+            if(tabcb)
+                tabcb(url);
+            free(url);
+        }
+
         respond(r, nil);
         return;
     }
@@ -131,7 +141,7 @@ fsdestroy(File *f)
 
 
 void
-startfs(const char *html, const char *text, UpdateCb cb, NotifyCb hcb, NotifyCb tcb)
+startfs(const char *html, const char *text, UpdateCb cb, NotifyCb hcb, TabCb tcb)
 {
     htmlfile.data = strdup((char*)html);
     htmlfile.len = strlen(html);

--- a/src/serve9p.h
+++ b/src/serve9p.h
@@ -3,6 +3,7 @@
 
 typedef void (*UpdateCb)(const char *html, const char *text);
 typedef void (*NotifyCb)(void);
-void startfs(const char *html, const char *text, UpdateCb pagecb, NotifyCb histcb, NotifyCb tabcb);
+typedef void (*TabCb)(const char *url);
+void startfs(const char *html, const char *text, UpdateCb pagecb, NotifyCb histcb, TabCb tabcb);
 
 #endif

--- a/src/tabs.c
+++ b/src/tabs.c
@@ -1,0 +1,91 @@
+#include <u.h>
+#include <libc.h>
+#include <thread.h>
+#include "fetcher.h"
+#include "parser.h"
+#include "tabs.h"
+
+typedef struct Tab Tab;
+struct Tab {
+    char *url;
+    char *html;
+    char *text;
+};
+
+static Tab *tabs;
+static int ntabs;
+static int current;
+static TabUpdateFn updatecb;
+static Lock tablock;
+
+void
+tabs_init(TabUpdateFn cb)
+{
+    updatecb = cb;
+    tabs = nil;
+    ntabs = 0;
+    current = -1;
+}
+
+static void
+tabproc(void *v)
+{
+    char *url = v;
+    char *html, *text;
+
+    html = fetch_url(url);
+    if(html == nil){
+        free(url);
+        return;
+    }
+    text = extract_text(html);
+    if(text == nil)
+        text = strdup(html);
+
+    lock(&tablock);
+    tabs = realloc(tabs, (ntabs+1)*sizeof(Tab));
+    tabs[ntabs].url = url;
+    tabs[ntabs].html = html;
+    tabs[ntabs].text = text;
+    current = ntabs;
+    ntabs++;
+    unlock(&tablock);
+
+    if(updatecb)
+        updatecb(html, text);
+}
+
+void
+tabs_new(const char *url)
+{
+    threadcreate(tabproc, strdup(url), 16*1024);
+}
+
+void
+tabs_switch(int index)
+{
+    char *html, *text;
+
+    lock(&tablock);
+    if(index < 0 || index >= ntabs){
+        unlock(&tablock);
+        return;
+    }
+    current = index;
+    html = tabs[current].html;
+    text = tabs[current].text;
+    unlock(&tablock);
+
+    if(updatecb)
+        updatecb(html, text);
+}
+
+int
+tabs_count(void)
+{
+    int n;
+    lock(&tablock);
+    n = ntabs;
+    unlock(&tablock);
+    return n;
+}

--- a/src/tabs.h
+++ b/src/tabs.h
@@ -1,0 +1,11 @@
+#ifndef TABS_H
+#define TABS_H
+
+typedef void (*TabUpdateFn)(const char *html, const char *text);
+
+void tabs_init(TabUpdateFn cb);
+void tabs_new(const char *url);
+void tabs_switch(int index);
+int tabs_count(void);
+
+#endif


### PR DESCRIPTION
## Summary
- implement simple tab manager
- pass new URL from 9P server to tab manager
- update main to initialize and use the tab manager
- compile new module in `mkfile`
- describe tab behaviour in roadmap

## Testing
- `./tests/run_tests.sh`
- `mk`