### PR TITLE
Strip HTTP headers from fetcher and update tests

### DIFF
--- a/src/fetcher.c
+++ b/src/fetcher.c
@@ -77,10 +77,20 @@ fetch_url(const char *url)
     fprint(fd, "GET /%s HTTP/1.0\r\nHost: %s\r\n\r\n", u.path, u.host);
     Binit(&buf, fd, OREAD);
 
+    int inhdr;
+
     data = nil;
     len = 0;
+    inhdr = 1;
     while((line = Brdline(&buf, '\n')) != nil){
         int n = Blinelen(&buf);
+        if(inhdr){
+            if((n == 2 && line[0]=='\r' && line[1]=='\n') ||
+               (n == 1 && line[0]=='\n')){
+                inhdr = 0;
+            }
+            continue;
+        }
         data = realloc(data, len + n + 1);
         if(data == nil)
             break;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -22,6 +22,11 @@ sleep 1
 
 ./fetch_url_test "http://127.0.0.1:$PORT/README.md" > /tmp/fetch.out
 kill $server_pid
+if grep -q '^HTTP/' /tmp/fetch.out; then
+  echo "fetch_url_test failed: headers present" >&2
+  cat /tmp/fetch.out >&2
+  exit 1
+fi
 if [ -s /tmp/fetch.out ]; then
   echo "fetch_url_test passed"
 else


### PR DESCRIPTION
## Summary
- discard HTTP headers in `fetch_url`
- fail the fetch URL test if headers appear in the output

## Testing
- `bash tests/run_tests.sh`