### PR TITLE
Fix realloc handling in fetch_url

### DIFF
--- a/src/fetcher.c
+++ b/src/fetcher.c
@@ -81,9 +81,13 @@ fetch_url(const char *url)
     len = 0;
     while((line = Brdline(&buf, '\n')) != nil){
         int n = Blinelen(&buf);
-        data = realloc(data, len + n + 1);
-        if(data == nil)
+        char *tmp = realloc(data, len + n + 1);
+        if(tmp == nil){
+            free(data);
+            data = nil;
             break;
+        }
+        data = tmp;
         memmove(data+len, line, n);
         len += n;
         data[len] = 0;


### PR DESCRIPTION
## Summary
- use a temporary pointer when reallocating
- free old buffer on realloc failure

## Testing
- `./tests/run_tests.sh`