### PR TITLE
Add mk presence check for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,14 @@ $ echo 'http://example.net/' > /mnt/gammera/ctl
 The current interface simply renders text in a window. Future versions
 will provide interactive controls (address bar, clickable links) built on
 top of the 9P interface.
+
+## Testing
+
+The test suite uses the Plan 9 `mk` build tool. Make sure `mk` is
+available in your `PATH` before running the tests. If you are on a Unix
+system without Plan 9 tools installed, run `scripts/install_deps.sh` to
+install plan9port and set up the environment.
+
+```sh
+tests/run_tests.sh
+```

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
 set -e
 cd "$(dirname "$0")"
+
+# ensure Plan 9 'mk' build tool is available
+if ! command -v mk >/dev/null 2>&1; then
+  echo "Error: 'mk' not found in PATH." >&2
+  echo "Install plan9port and ensure mk is in your PATH (try scripts/install_deps.sh)." >&2
+  exit 1
+fi
 mk clean >/dev/null
 mk parser_test parseurl_test fetch_url_test >/tmp/test_build.log && tail -n 20 /tmp/test_build.log
 


### PR DESCRIPTION
## Summary
- alert when `mk` isn't in PATH before building tests
- document the requirement to install plan9port before running tests

## Testing
- `tests/run_tests.sh`
