### PR TITLE
Rename tabsupdate callback

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -43,8 +43,11 @@ historyupdate(void)
     close(fd);
 }
 
+/*
+ * Refresh the bookmark list by reading the 9P bookmarks file.
+ */
 static void
-tabsupdate(void)
+bookmarkupdate(void)
 {
     int fd, n;
     char *buf;
@@ -146,7 +149,7 @@ threadmain(int argc, char *argv[])
     flushimage(display, 1);
 
     current = strdup(text);
-    startfs(data, text, update, historyupdate, tabsupdate);
+    startfs(data, text, update, historyupdate, bookmarkupdate);
     proccreate(navproc, nil, 8192);
 
 

--- a/src/serve9p.c
+++ b/src/serve9p.c
@@ -216,7 +216,7 @@ fsdestroy(File *f)
 
 
 void
-startfs(const char *html, const char *text, UpdateCb cb, NotifyCb hcb, TabCb tcb)
+startfs(const char *html, const char *text, UpdateCb cb, NotifyCb hcb, TabCb bookmarkcb)
 {
     htmlfile.data = strdup((char*)html);
     htmlfile.len = strlen(html);
@@ -229,7 +229,7 @@ startfs(const char *html, const char *text, UpdateCb cb, NotifyCb hcb, TabCb tcb
     tabfile.len = 0;
     updatecb = cb;
     historycb = hcb;
-    tabcb = tcb;
+    tabcb = bookmarkcb;
 
     fs.tree = alloctree(nil, nil, DMDIR|0555, fsdestroy);
     createfile(fs.tree->root, "page.html", nil, 0444, &htmlfile);

--- a/src/serve9p.h
+++ b/src/serve9p.h
@@ -4,6 +4,9 @@
 typedef void (*UpdateCb)(const char *html, const char *text);
 typedef void (*NotifyCb)(void);
 typedef void (*TabCb)(const char *url);
-void startfs(const char *html, const char *text, UpdateCb pagecb, NotifyCb histcb, TabCb tabcb);
+/* start the 9P file service with callbacks for page updates, history writes,
+ * and bookmark updates */
+void startfs(const char *html, const char *text, UpdateCb pagecb,
+    NotifyCb histcb, TabCb bookmarkcb);
 
 #endif


### PR DESCRIPTION
## Summary
- rename `tabsupdate` to `bookmarkupdate`
- pass `bookmarkupdate` when starting the 9P service
- update startfs prototype and usage comments

## Testing
- `tests/run_tests.sh`