### PR TITLE
Fix bookmarkupdate signature

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -47,8 +47,9 @@ historyupdate(void)
  * Refresh the bookmark list by reading the 9P bookmarks file.
  */
 static void
-bookmarkupdate(void)
+bookmarkupdate(const char *url)
 {
+    USED(url);
     int fd, n;
     char *buf;
     Dir *d;


### PR DESCRIPTION
## Summary
- accept URL parameter in `bookmarkupdate`
- make sure the unused parameter is marked with `USED`

## Testing
- `./tests/run_tests.sh` *(fails: fetch_url_test headers present)*