### PR TITLE
Add Plan 9 guidelines and fetcher fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Contributing Guidelines for Gammera
+
+This project follows the Plan 9 design philosophy. Programs should be small and focused, communicate through well-defined interfaces (often files or pipes), and avoid unnecessary global state. Code should be easy to compose with other small tools.
+
+## Coding Style
+
+- Stick to the Plan 9 C dialect as provided by `libc`, `libdraw`, and `libthread`.
+- Keep each program minimal. Prefer short functions and a single clear purpose per file when possible.
+- Avoid large global structures. Pass state explicitly and limit mutable shared data.
+- Maintain portability to native Plan 9 and plan9port. Do not add heavy dependencies beyond the core Plan 9 libraries unless absolutely necessary.
+- Comments should explain *why* something is done, not just *what* the code does.
+
+## Building & Testing
+
+Use the Plan 9 `mk` tool for builds. From the project root run:
+
+```
+mk all
+```
+
+To execute the test suite run:
+
+```
+tests/run_tests.sh
+```
+
+Both commands expect a Plan 9 or plan9port environment. See `scripts/install_deps.sh` if you need to set up plan9port on a Unix system.
+
+Following these guidelines will help keep Gammera aligned with the Plan 9 way of writing simple, composable software.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ Gammera is a web browser designed to work on Plan 9 from Bell Labs. This
 repository contains the beginnings of an experimental implementation
 written in the Plan 9 style. It is **not** a complete browser yet.
 
+## Coding Conventions
+
+Gammera follows the Plan 9 philosophy of composing small programs that
+cooperate through simple interfaces. Keep global state to a minimum and
+pass data explicitly between functions. Use the core Plan 9 libraries
+(`libc`, `libdraw`, `libthread`) to remain portable between native Plan 9
+and plan9port. Avoid adding heavy external dependencies.
+
 ## Building on Plan 9
 
 Plan 9 uses the `mk` build tool. From a Plan 9 environment you can run:

--- a/mkfile
+++ b/mkfile
@@ -1,5 +1,10 @@
 <$PLAN9/src/mkhdr
 
+
+# name of the resulting executable
+TARG=gammera
+
+# object files for the build
 OFILES=main.$O fetcher.$O parser.$O serve9p.$O tabs.$O fs.$O
 # serve9p.$O provides the consolidated 9P interface
 

--- a/src/fetcher.c
+++ b/src/fetcher.c
@@ -84,6 +84,12 @@ fetch_url(const char *url)
     inhdr = 1;
     while((line = Brdline(&buf, '\n')) != nil){
         int n = Blinelen(&buf);
+        if(inhdr){
+            if((n == 2 && line[0] == '\r' && line[1] == '\n') ||
+               (n == 1 && (line[0] == '\n' || line[0] == '\r')))
+                inhdr = 0;
+            continue;
+        }
         char *tmp = realloc(data, len + n + 1);
         if(tmp == nil){
             free(data);


### PR DESCRIPTION
## Summary
- add `AGENTS.md` describing Plan 9 style and build instructions
- explain coding conventions in `README.md`
- define `TARG` in `mkfile`
- strip HTTP headers in `fetch_url`

## Testing
- `tests/run_tests.sh`