### PR TITLE
Add 9front TLS install helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ This will compile the sources under `src/` using the Plan 9 toolchain.
 For Linux or other Unix-like systems you can install plan9port and the
 required build tools using `scripts/install_deps.sh` before running `mk`.
 This script installs Plan9port and configures your PATH so the `mk` build tool is available.
-It also installs `libssl-dev` so that HTTPS support can be built. If you are
-on a native Plan 9 system, ensure the appropriate TLS library is installed
-(for example the 9front TLS tools).
+It also installs `libssl-dev` so that HTTPS support can be built. On a native Plan 9 system run `scripts/install_tls9front.sh` to fetch the 9front TLS tools before building.
 Note that the install script downloads packages from the network and may fail
 if your environment lacks internet access.
 

--- a/scripts/install_tls9front.sh
+++ b/scripts/install_tls9front.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Fetch and build the 9front TLS tools.
+# Installs into $PLAN9 if set, otherwise /usr/local to preserve Plan 9 style.
+set -e
+
+PREFIX="${PLAN9:-/usr/local}"
+SRCDIR="$PREFIX/src/9front_tls"
+REPO="https://git.9front.org/plan9front/tls"
+
+# Clone or update the repository
+if [ ! -d "$SRCDIR" ]; then
+    echo "Cloning TLS tools from $REPO"
+    git clone "$REPO" "$SRCDIR"
+else
+    echo "Updating TLS tools in $SRCDIR"
+    git -C "$SRCDIR" pull
+fi
+
+cd "$SRCDIR"
+
+echo "Building TLS tools..."
+PLAN9="$PREFIX" mk clean || true
+PLAN9="$PREFIX" mk
+
+# Install with sudo if required
+if [ -w "$PREFIX" ]; then
+    PLAN9="$PREFIX" mk install
+else
+    sudo PLAN9="$PREFIX" mk install
+fi


### PR DESCRIPTION
## Summary
- script to fetch and build the 9front TLS tools
- reference the TLS install script in README

## Testing
- `tests/run_tests.sh`