### PR TITLE
Add rendering plans and feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ This script installs Plan9port and configures your PATH so the `mk` build tool i
 It also installs `libssl-dev` so that HTTPS support can be built. If you are
 on a native Plan 9 system, ensure the appropriate TLS library is installed
 (for example the 9front TLS tools).
+Optional features are toggled at build time. Set `TLS=1` to enable
+HTTPS fetching and `JS=1` to include the experimental JavaScript
+interpreter:
+
+```sh
+TLS=1 JS=1 mk all
+```
 Note that the install script downloads packages from the network and may fail
 if your environment lacks internet access.
 
@@ -51,6 +58,9 @@ Gamera is still in an early stage, but a minimal program can fetch a
 web page, strip basic HTML tags, render the text line by line, and
 expose the page contents via a small 9P file system. Pass a URL on the
 command line (or omit it to fetch `http://example.com/`).
+Only a small subset of HTML is handled.  When built with `libhtml`
+paragraphs, headings and links are displayed; otherwise tags are stripped
+leaving plain text.
 See `doc/roadmap.md` for planned tasks.
 
 ## 9P Interface

--- a/doc/design.md
+++ b/doc/design.md
@@ -58,3 +58,16 @@ Gamera currently downloads a page using `hget`, strips HTML tags to
 extract plain text, and displays the result in a window using `libdraw`.
 The 9P interface described above is implemented and can be used to fetch
 new pages. More advanced parsing and rendering remain to be implemented.
+
+## Rendering with libhtml
+
+The renderer is intentionally small.  When built with Plan 9's `libhtml`
+it can layout a subset of HTML elements such as paragraphs, headings and
+links.  Without `libhtml` the program falls back to the simple text
+extraction described above.  The goal is to keep the core code minimal
+while allowing improved rendering when the optional library is present.
+
+Future work includes optional JavaScript support through a small
+interpreter and the ability to fetch pages over HTTPS using the system
+TLS library.  Both features are planned as compile time options so a
+plain build remains lightweight.

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -23,3 +23,9 @@ Writing a URL to `/mnt/gamera/tabctl` opens that address in a new tab. Each
 tab runs in its own thread and can be selected from a contextual menu like
 other Plan 9 programs. Switching tabs notifies the main window to redraw with
 the selected page contents.
+
+## Tests and Scripts
+
+Unit tests live in the `tests/` directory and are built with Plan 9 `mk`.
+Run `tests/run_tests.sh` to compile and execute them. Helper scripts such
+as `scripts/install_deps.sh` install plan9port and optional TLS support.


### PR DESCRIPTION
## Summary
- describe optional rendering and HTTPS in design docs
- clarify HTML subset and feature flags in README
- mention tests and install script in the roadmap

## Testing
- `mk` *(fails: unknown types in main.c)*
- `OFFLINE=1 tests/run_tests.sh`