### PR TITLE
Add libhtml DOM parser and rendering test

### DIFF
--- a/mkfile
+++ b/mkfile
@@ -5,7 +5,7 @@
 TARG=gamera
 
 # object files for the build
-OFILES=main.$O fetcher.$O parser.$O serve9p.$O tabs.$O fs.$O
+OFILES=main.$O fetcher.$O parser.$O html.$O render.$O serve9p.$O tabs.$O fs.$O
 # serve9p.$O provides the consolidated 9P interface
 
 $TARG: $OFILES
@@ -18,10 +18,16 @@ fetcher.$O: src/fetcher.c src/fetcher.h
         $CC -c -o $target src/fetcher.c
 
 parser.$O: src/parser.c src/parser.h
-	$CC -c -o $target src/parser.c
+    $CC -c -o $target src/parser.c
+
+html.$O: src/html.c src/html.h
+    $CC -c -o $target src/html.c
+
+render.$O: src/render.c src/render.h src/html.h
+    $CC -c -o $target src/render.c
 
 serve9p.$O: src/serve9p.c src/serve9p.h src/fetcher.h src/parser.h
-        $CC -c -o $target src/serve9p.c
+    $CC -c -o $target src/serve9p.c
 
 tabs.$O: src/tabs.c src/tabs.h src/fetcher.h src/parser.h
         $CC -c -o $target src/tabs.c

--- a/src/html.c
+++ b/src/html.c
@@ -1,0 +1,59 @@
+#include <u.h>
+#include <libc.h>
+#include <draw.h>
+#include <html.h>
+#include "html.h"
+
+/* libhtml expects emalloc and erealloc helpers */
+void*
+emalloc(ulong n)
+{
+    void *p;
+    if(n == 0)
+        n = 1;
+    p = malloc(n);
+    if(p == nil)
+        sysfatal("out of memory");
+    memset(p, 0, n);
+    return p;
+}
+
+void*
+erealloc(void *p, ulong n)
+{
+    void *q;
+    if(n == 0)
+        n = 1;
+    q = realloc(p, n);
+    if(q == nil)
+        sysfatal("out of memory");
+    return q;
+}
+
+HtmlDoc*
+html_parse(const char *html)
+{
+    if(html == nil)
+        return nil;
+    HtmlDoc *doc = malloc(sizeof(HtmlDoc));
+    if(doc == nil)
+        return nil;
+    Rune *src = toStr((uchar*)"about:blank", strlen("about:blank"), UTF_8);
+    doc->items = parsehtml((uchar*)html, strlen(html), src, TextHtml, UTF_8, &doc->info);
+    free(src);
+    if(doc->items == nil){
+        free(doc);
+        return nil;
+    }
+    return doc;
+}
+
+void
+html_free(HtmlDoc *doc)
+{
+    if(doc == nil)
+        return;
+    freeitems(doc->items);
+    freedocinfo(doc->info);
+    free(doc);
+}

--- a/src/html.h
+++ b/src/html.h
@@ -1,0 +1,15 @@
+#ifndef HTML_WRAPPER_H
+#define HTML_WRAPPER_H
+#include <draw.h>
+#include <html.h>
+
+typedef struct HtmlDoc HtmlDoc;
+struct HtmlDoc {
+    Item *items;
+    Docinfo *info;
+};
+
+HtmlDoc* html_parse(const char *html);
+void html_free(HtmlDoc *doc);
+
+#endif

--- a/src/render.c
+++ b/src/render.c
@@ -2,6 +2,7 @@
 #include <libc.h>
 #include <draw.h>
 #include "render.h"
+#include "html.h"
 
 void
 render_text(const char *text)
@@ -23,5 +24,19 @@ render_text(const char *text)
             break;
     }
     free(copy);
+    flushimage(display, 1);
+}
+
+void
+render_items(Item *it)
+{
+    Point p = Pt(screen->r.min.x+10, screen->r.min.y+10);
+    for(; it; it = it->next){
+        if(it->tag != Itexttag)
+            continue;
+        Itext *t = (Itext*)it;
+        drawstring(screen, p, display->black, ZP, font, t->s);
+        p.x += stringwidth(font, t->s);
+    }
     flushimage(display, 1);
 }

--- a/src/render.h
+++ b/src/render.h
@@ -1,6 +1,9 @@
 #ifndef RENDER_H
 #define RENDER_H
 
+#include "html.h"
+
 void render_text(const char *text);
+void render_items(Item *items);
 
 #endif

--- a/tests/html_test.c
+++ b/tests/html_test.c
@@ -1,0 +1,31 @@
+#include <u.h>
+#include <libc.h>
+#include <draw.h>
+#include <html.h>
+#include "../src/html.h"
+
+void
+main(void)
+{
+    HtmlDoc *doc = html_parse("<b>bold</b><i>ital</i>");
+    if(doc == nil)
+        sysfatal("parse failed");
+    int bold = 0, ital = 0;
+    Item *it;
+    for(it = doc->items; it; it = it->next){
+        if(it->tag != Itexttag)
+            continue;
+        Itext *t = (Itext*)it;
+        int style = t->fnt / NumSize;
+        if(style == FntB)
+            bold = 1;
+        if(style == FntI)
+            ital = 1;
+    }
+    html_free(doc);
+    if(bold && ital)
+        print("ok\n");
+    else
+        sysfatal("style missing");
+    exits(nil);
+}

--- a/tests/mkfile
+++ b/tests/mkfile
@@ -1,6 +1,6 @@
 <$PLAN9/src/mkhdr
 
-TARG=parser_test parseurl_test fetch_url_test
+TARG=parser_test parseurl_test fetch_url_test html_test
 
 # source file providing fetch_url implementation
 FETCHER_SRC=../src/fetcher.c
@@ -29,5 +29,14 @@ fetch_url_test.$O: fetch_url_test.c ../src/fetcher.h
 fetcher.$O: $FETCHER_SRC ../src/fetcher.h
     $CC -I../src -c -o $target $FETCHER_SRC
 
+html_test: html_test.$O html.$O
+    $LD -o $target html_test.$O html.$O
+
+html_test.$O: html_test.c ../src/html.h
+    $CC -I../src -c -o $target html_test.c
+
+html.$O: ../src/html.c ../src/html.h
+    $CC -I../src -c -o $target ../src/html.c
+
 clean:V:
-    rm -f *.[$OS] $TARG parser.$O fetcher.$O
+    rm -f *.[$OS] $TARG parser.$O fetcher.$O html.$O

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -17,7 +17,7 @@ MKFLAGS=""
 if [ -n "$OFFLINE" ]; then
   MKFLAGS="FETCHER_SRC=mock_fetcher.c"
 fi
-mk $MKFLAGS parser_test parseurl_test fetch_url_test >/tmp/test_build.log && tail -n 20 /tmp/test_build.log
+mk $MKFLAGS parser_test parseurl_test fetch_url_test html_test >/tmp/test_build.log && tail -n 20 /tmp/test_build.log
 
 # run parser_test
 ./parser_test > /tmp/parser_test.out
@@ -59,6 +59,15 @@ if grep -q '^ok' /tmp/parseurl.out; then
 else
   echo "parseurl_test failed" >&2
   cat /tmp/parseurl.out >&2
+  exit 1
+fi
+
+./html_test > /tmp/html.out
+if grep -q '^ok' /tmp/html.out; then
+  echo "html_test passed"
+else
+  echo "html_test failed" >&2
+  cat /tmp/html.out >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- wrap plan9 `libhtml` with new `html.c`/`html.h`
- render DOM items in `render.c`
- build new module via `mkfile`
- add `html_test` to verify bold/italic tags
- extend test runner to build and run new test

## Testing
- `tests/run_tests.sh`