### PR TITLE
Update docs for libhtml dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ This script installs Plan9port and configures your PATH so the `mk` build tool i
 It also installs `libssl-dev` so that HTTPS support can be built. If you are
 on a native Plan 9 system, ensure the appropriate TLS library is installed
 (for example the 9front TLS tools).
+Parsing relies on Plan 9's `libhtml`. The wrapper implementation in
+`src/html.c` requires `libhtml` and its dependencies to be present in your
+Plan 9 or plan9port environment.
 Optional features are toggled at build time. Set `TLS=1` to enable
 HTTPS fetching and `JS=1` to include the experimental JavaScript
 interpreter:
@@ -61,7 +64,8 @@ expose the page contents via a small 9P file system. Pass a URL on the
 command line (or omit it to fetch `http://example.com/`).
 Only a small subset of HTML is handled.  When built with `libhtml`
 paragraphs, headings and links are displayed; otherwise tags are stripped
-leaving plain text.
+leaving plain text. DOM parsing is implemented in `src/html.c`, which
+wraps Plan 9's `libhtml` library.
 See `doc/roadmap.md` for planned tasks.
 
 ## 9P Interface

--- a/doc/design.md
+++ b/doc/design.md
@@ -10,7 +10,10 @@ access.
 * **Fetcher** – Retrieves HTTP/HTTPS resources using the Plan 9 network
   stack. Initially this may rely on external tools like `hget`.
 
-* **Parser** – Parses HTML and CSS into a simple DOM representation.
+* **Parser** – Parses HTML and CSS into a simple DOM representation. The
+  helper in `src/html.c` wraps Plan 9's `libhtml` and is required for DOM
+  parsing. Ensure `libhtml` and its dependencies are available in your
+  Plan 9 or plan9port environment.
 * **Renderer** – Uses `libdraw` and `libhtml` (when available) to render
   pages into windows.
 * **UI** – Provides a minimal interface using the Plan 9 window system.


### PR DESCRIPTION
## Summary
- note that `src/html.c` wraps Plan 9's libhtml for DOM parsing
- clarify that libhtml must be present in the Plan 9/plan9port environment

## Testing
- `mk` *(fails: unknown type names)*
- `tests/run_tests.sh`